### PR TITLE
Added a default value to the location variable.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,8 @@ variable "kubernetes_version" {
 
 variable "location" {
   type        = string
-  description = "The location where you want to create the cluster, must be a valid GCP region or zone"
+  description = "The location where you want to create the cluster, must be a valid GCP region or zone. The default value will create a regional cluster."
+  default = "europe-west1"
 }
 
 variable "zones" {


### PR DESCRIPTION
Added the default value to the "location" parameter of the terraform module.
- if the variable is not initialized in a new cluster, it will be a regional cluster in the region "europe-west1".
- the previous executions and extensions that use this module that did override the variable will continue to work as always.