### PR TITLE
Fix node_count bug and added new logic for max_surge

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ locals {
     disk_size_gb     = 50
     service_account  = ""
     machine_image    = "COS"
-    max_surge        = 1
+    max_surge        = 0
     max_unavailable  = 0
     preemptible      = false
   }, var.defaults_node_pools_configs)

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -40,7 +40,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   upgrade_settings {
-    max_surge       = max(each.value.max_surge == 0 ? ceil(each.value.min_size/4) : each.value.max_surge, 1)
+    max_surge       = each.value.max_surge == 0 ? max(ceil(each.value.min_size/4), 1) : each.value.max_surge
     max_unavailable = each.value.max_unavailable
   }
 

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -28,8 +28,9 @@ resource "google_container_node_pool" "pools" {
     auto_upgrade = false
   }
 
-  initial_node_count = each.value.min_size
+  initial_node_count = each.value.min_size == each.value.max_size ? null : each.value.min_size
   node_count         = each.value.min_size != each.value.max_size ? null : each.value.min_size
+
   dynamic "autoscaling" {
     for_each = each.value.min_size != each.value.max_size ? [each.value] : []
     content {
@@ -37,8 +38,9 @@ resource "google_container_node_pool" "pools" {
       max_node_count = lookup(autoscaling.value, "max_size", autoscaling.value.min_size)
     }
   }
+
   upgrade_settings {
-    max_surge       = each.value.max_surge
+    max_surge       = max(each.value.max_surge == 0 ? ceil(each.value.min_size/4) : each.value.max_surge, 1)
     max_unavailable = each.value.max_unavailable
   }
 
@@ -76,7 +78,6 @@ resource "google_container_node_pool" "pools" {
     ignore_changes = [
       initial_node_count,
       node_config["taint"],
-
     ]
   }
 


### PR DESCRIPTION
This PR adds the following changes:

- fix `initial_node_count` and `node_count` both set when `min_size` and `max_size` are set at the same value
- changed `max_sourge` to a quarter of `min_size`, the value is rounded to the upper integer (eg. if `min_size` is 6 then `max_sourge` will be 2)