### PR TITLE
Explicity turn off managed prometheus

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -115,6 +115,12 @@ resource "google_container_cluster" "master" {
     enabled = var.vertical_pod_autoscaling_enabled
   }
 
+  monitoring_config {
+    managed_prometheus {
+      enabled = false
+    }
+  }
+
   addons_config {
     http_load_balancing {
       disabled = false


### PR DESCRIPTION
With the new version of the providers if the managed prometheus feature is not explicitly turned off it will be enabled by default.

This PR will add the option to false.