### PR TITLE
Add disk_type customization for nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The node_pools variable takes the following parameters:
 | machine_type | The GCP instance machine type to use | string |  | ✅ | Required |
 | machine_image | The GCP instance machine image name to use | string | `"COS"` | ✅ | Optional |
 | min_cpu_platform | The minimum CPU platform to use, if not set the zone default will be used | string | `""` | ✅ | Optional |
+| disk_type | The root disk type of the nodes. | string | `pd-standard` | ✅ | Optional |
 | disk_size_gb | The root disk size of the nodes, expressed in GB. The minimum value is `10` | number | `50` | ✅ | Optional |
 | service_account | The service account to be used by the Node VMs | string | `""` | ✅ | Optional |
 | node_locations | A comma separated list of zone location for the pool | string | `""` | ❌ | Optional |

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ locals {
   defaults_node_pools_configs = merge({
     min_size         = 3
     min_cpu_platform = ""
+    disk_type        = "pd-standard"
     disk_size_gb     = 50
     service_account  = ""
     machine_image    = "COS"

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -50,8 +50,8 @@ resource "google_container_node_pool" "pools" {
     machine_type = each.value.machine_type
 
     local_ssd_count  = 0
+    disk_type        = each.value.disk_type
     disk_size_gb     = each.value.disk_size_gb
-    disk_type        = "pd-standard"
     min_cpu_platform = each.value.min_cpu_platform
     preemptible      = each.value.preemptible
     spot             = each.value.spot


### PR DESCRIPTION
For enabling the support of the c3 general purpose machine type we need the ability to change the disk type because the pd-standard one are not supported by them.

This change allow just that and will keep the pd-standard as default if no value is used.